### PR TITLE
Fix S3 API polling configuration drift in Terraform plan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,10 @@ resource "newrelic_cloud_aws_integrations" "api_polling" {
     for_each = var.link_aws_account_api_polling_aws_integrations.s3.enabled ? [1] : []
     content {
       metrics_polling_interval = var.link_aws_account_api_polling_aws_integrations.s3.metrics_polling_interval
+      fetch_extended_inventory = var.link_aws_account_api_polling_aws_integrations.s3.fetch_extended_inventory
+      fetch_tags               = var.link_aws_account_api_polling_aws_integrations.s3.fetch_tags
+      tag_key                  = var.link_aws_account_api_polling_aws_integrations.s3.tag_key
+      tag_value                = var.link_aws_account_api_polling_aws_integrations.s3.tag_value
     }
   }
   dynamic "doc_db" {

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,10 @@ variable "link_aws_account_api_polling_aws_integrations" {
     s3 = optional(object({
       enabled                  = optional(bool, false)
       metrics_polling_interval = optional(number, null)
+      fetch_extended_inventory = optional(bool, null)
+      fetch_tags               = optional(bool, null)
+      tag_key                  = optional(string, null)
+      tag_value                = optional(string, null)
     }), {})
     doc_db = optional(object({
       enabled                  = optional(bool, false)


### PR DESCRIPTION
# Fix S3 API polling configuration drift in Terraform plan

## Problem

When enabling API polling for S3 monitoring configuration, there was a bug where Terraform plan always showed configuration drift due to missing optional parameters in the Terraform configuration file.

Specifically, the following diff was displayed every time:

```diff
  # module.aws-account-integration.newrelic_cloud_aws_integrations.api_polling[0] will be updated in-place
  ~ resource "newrelic_cloud_aws_integrations" "api_polling" {
        id                = "******"
        # (2 unchanged attributes hidden)

      ~ s3 {
          - fetch_tags               = true -> null
          - metrics_polling_interval = 300 -> null
            # (1 unchanged attribute hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Solution

Following the [New Relic Terraform Provider documentation](https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/cloud_aws_integrations#integration-blocks), I added the following optional parameters available for S3 integration to the variable definitions:

- `fetch_extended_inventory`
- `fetch_tags`
- `tag_key`
- `tag_value`

### Changed Files

- `variables.tf`: Added optional parameters for S3 integration
- `main.tf`: Applied the added parameters to resource definitions

## Verification

After the fix, I verified that no configuration drift occurs when running Terraform plan:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.
```

## Impact

- **Breaking Change**: None
- **Impact on existing configurations**: None (all new parameters are optional with default value of null)
- **Backward compatibility**: Fully maintained

## Testing

- [x] Verified that no configuration drift occurs with existing S3 integration settings
- [x] Verified that new optional parameters work correctly
- [x] Verified that Terraform plan/apply executes successfully

## Checklist

- [x] Verified that code changes work as intended
- [x] Verified that existing functionality is not affected
- [x] Checked if documentation updates are needed (not required for this change)
- [x] Verified that backward compatibility is maintained
