### PR TITLE
Fix S3 bucket versioning error when aws_config_enabled is false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -732,8 +732,8 @@ resource "aws_s3_bucket" "config" {
 }
 
 resource "aws_s3_bucket_versioning" "config" {
-  count  = var.create_metric_streams_aws_resources ? 1 : 0
-  bucket = var.create_metric_streams_aws_resources ? aws_s3_bucket.config[0].bucket : ""
+  count  = var.create_metric_streams_aws_resources && var.aws_config_enabled ? 1 : 0
+  bucket = var.create_metric_streams_aws_resources && var.aws_config_enabled ? aws_s3_bucket.config[0].bucket : ""
   versioning_configuration {
     status = "Enabled"
   }


### PR DESCRIPTION
# Fix S3 bucket versioning error when aws_config_enabled is false

## Overview

Fixed an issue where the `aws_s3_bucket_versioning.config` resource was causing errors when `aws_config_enabled=false`.

## Problem

When AWS Config is disabled (`aws_config_enabled=false`), the following error was occurring:

```
╷
│ Error: Invalid index
│ 
│   on .terraform/modules/aws-account-integration/main.tf line 736, in resource "aws_s3_bucket_versioning" "config":
│  736:   bucket = var.create_metric_streams_aws_resources ? aws_s3_bucket.config[0].bucket : ""
│     ├────────────────
│     │ aws_s3_bucket.config is empty tuple
│ 
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
```

## Root Cause

The creation condition for the `aws_s3_bucket_versioning.config` resource was incomplete.

- The `aws_s3_bucket.config` is created with the condition `var.create_metric_streams_aws_resources && var.aws_config_enabled`
- However, `aws_s3_bucket_versioning.config` was created with only the condition `var.create_metric_streams_aws_resources`
- Therefore, when `aws_config_enabled=false`, the bucket doesn't exist but the versioning configuration was still being created, causing an error

## Solution

Added `var.aws_config_enabled` to the creation condition of the `aws_s3_bucket_versioning.config` resource.

### Changes

```diff
resource "aws_s3_bucket_versioning" "config" {
-  count  = var.create_metric_streams_aws_resources ? 1 : 0
-  bucket = var.create_metric_streams_aws_resources ? aws_s3_bucket.config[0].bucket : ""
+  count  = var.create_metric_streams_aws_resources && var.aws_config_enabled ? 1 : 0
+  bucket = var.create_metric_streams_aws_resources && var.aws_config_enabled ? aws_s3_bucket.config[0].bucket : ""
   versioning_configuration {
     status = "Enabled"
   }
}
```

## Testing

- Executed `terraform plan` and `terraform apply` and confirmed that the error has been resolved
- Confirmed proper operation in environments where `aws_config_enabled=false`

## Impact

- **No Breaking Changes**: Existing behavior is not affected
- **When AWS Config is enabled**: S3 bucket versioning is configured as before
- **When AWS Config is disabled**: S3 bucket versioning resource is not created (error resolved)

## Checklist

- [x] Code review completed
- [x] Testing in test environment completed
- [x] Confirmed that `terraform plan` executes without errors
- [x] Confirmed that `terraform apply` completes successfully
- [x] Confirmed no impact on existing resources
